### PR TITLE
Fix update option usage in snapshot(data, update)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,10 @@ function getSpec ({file, line}) {
 }
 
 function snapshot (what, update) {
+  if (update) {
+    Object.assign(opts, { update: update })
+  }
+
   const sites = stackSites()
   if (sites.length < 3) {
     // hmm, maybe there is test (like we are inside Cypress)


### PR DESCRIPTION
Currently the update option is never used to override the default options, which makes it impossible to update a single test update. This fixes it.